### PR TITLE
Include rsync RPM package.

### DIFF
--- a/rhis-base/dnf_requirements.txt
+++ b/rhis-base/dnf_requirements.txt
@@ -11,3 +11,4 @@ iputils
 bash-completion
 tmux
 jq
+rsync


### PR DESCRIPTION
`rsync` RPM package needed in order to utilize the `ansible.posix.synchronize` module, a rsync wrapper for Ansible. 